### PR TITLE
Add links to Dart port

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ With this system, quiz applications can move away from “daily review piles” 
 
 Ebisu also enables apps to provide an infinite stream of quizzes for students who are cramming. Thus, Ebisu intelligently handles over-reviewing as well as under-reviewing.
 
-This document is a literate source: it contains a detailed mathematical description of the underlying algorithm as well as source code for a Python implementation (requires Scipy and Numpy). Separate implementations in [JavaScript (Ebisu.js)](https://fasiha.github.io/ebisu.js/) and [Java (ebisu-java)](https://github.com/fasiha/ebisu-java) exist.
+This document is a literate source: it contains a detailed mathematical description of the underlying algorithm as well as source code for a Python implementation (requires Scipy and Numpy). Separate implementations in [JavaScript (Ebisu.js)](https://fasiha.github.io/ebisu.js/), [Java (ebisu-java)](https://github.com/fasiha/ebisu-java) and [Dart (ebisu_dart)](https://github.com/ttencate/ebisu_dart) exist.
 
 The next section is a [Quickstart](#quickstart) guide to setup and usage. See this if you know you want to use Ebisu in your app.
 
@@ -79,7 +79,7 @@ Finally, the [Source Code](#source-code) section presents the literate source of
 
 **Further information** [Module docstrings](./doc/doc.md) in a pinch but full details plus literate source below, under [Source code](#source-code).
 
-**Alternative implementations** [Ebisu.js](https://fasiha.github.io/ebisu.js/) is a JavaScript port for browser and Node.js. [ebisu-java](https://github.com/fasiha/ebisu-java) is for Java and JVM languages.
+**Alternative implementations** [Ebisu.js](https://fasiha.github.io/ebisu.js/) is a JavaScript port for browser and Node.js. [ebisu-java](https://github.com/fasiha/ebisu-java) is for Java and JVM languages. [ebisu_dart](https://github.com/ttencate/ebisu_dart) is a Dart port for browser and native targets.
 
 ## How it works
 


### PR DESCRIPTION
GitHub repository: https://github.com/ttencate/ebisu_dart
Home page on pub.dev: https://pub.dev/packages/ebisu_dart  
Documentation (not yet available at the time of writing): https://pub.dev/documentation/ebisu_dart